### PR TITLE
Updated documentation and made implementation more robust to Gradle API changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,10 @@ main | String | *Required.* The qualified name of the main java class to execute
 jvmArgs | List<String> | *Optional.* The list of arguments to give to the jvm when launching the java main class.
 environment | Two Strings OR one Map<String, String> | *Optional.* Environment variables to launch the java main class with. You can either assign a Map with the '=' operator, or pass 2 Strings as key/value to the function. Note that multiple calls to this function are supported.
 
+## Compatibility
+
+Gradle Version | ExecFork version
+--- | ---
+< 4.10 | 0.1.8
+4.10 - 5.2.x | 0.1.9
+since 5.3.0 | 0.1.10

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+
 plugins {
     id("com.gradle.plugin-publish").version("0.9.7")
     id("org.jetbrains.kotlin.jvm").version("1.2.40")
@@ -50,6 +52,9 @@ tasks {
     }
     buildSampleProjects.dependsOn("install")
     "build" { finalizedBy(buildSampleProjects) }
+    named<Test>("test") {
+        testLogging.exceptionFormat = TestExceptionFormat.FULL
+    }
 }
 
 
@@ -67,4 +72,3 @@ artifacts {
     add("archives", javadocJar)
     add("archives", sourcesJar)
 }
-

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/github/psxpaul/ExecForkPlugin.kt
+++ b/src/main/kotlin/com/github/psxpaul/ExecForkPlugin.kt
@@ -27,8 +27,8 @@ class ExecForkPlugin : Plugin<Project> {
     val log: Logger = LoggerFactory.getLogger(ExecForkPlugin::class.java)
 
     override fun apply(project: Project) {
-        if (GradleVersion.current() < GradleVersion.version("4.10")) {
-            throw GradleException("This version of the plugin is incompatible with gradle < 4.10! Please use execfork version 0.1.8, or upgrade gradle.")
+        if (GradleVersion.current() < GradleVersion.version("5.3")) {
+            throw GradleException("This version of the plugin is incompatible with gradle < 5.3! Please use execfork version 0.1.9, or upgrade gradle.")
         }
 
         val forkTasks: ArrayList<AbstractExecFork> = ArrayList()

--- a/src/main/kotlin/com/github/psxpaul/task/ExecFork.kt
+++ b/src/main/kotlin/com/github/psxpaul/task/ExecFork.kt
@@ -1,9 +1,7 @@
 package com.github.psxpaul.task
 
-import org.gradle.api.internal.file.DefaultFileCollectionFactory
-import org.gradle.internal.file.PathToFileResolver
 import org.gradle.process.ProcessForkOptions
-import org.gradle.process.internal.DefaultJavaForkOptions
+import org.gradle.process.internal.JavaForkOptionsFactory
 import javax.inject.Inject
 
 /**
@@ -14,8 +12,8 @@ import javax.inject.Inject
  * @see AbstractExecFork
  * @see ProcessForkOptions for all available configuration options
  */
-open class ExecFork @Inject constructor(fileResolver: PathToFileResolver) : AbstractExecFork(),
-        ProcessForkOptions by DefaultJavaForkOptions(fileResolver, DefaultFileCollectionFactory(fileResolver, null)) {
+open class ExecFork @Inject constructor(forkOptionsFactory: JavaForkOptionsFactory) : AbstractExecFork(),
+        ProcessForkOptions by forkOptionsFactory.newJavaForkOptions() {
 
     /**
      * The path to the executable to run

--- a/src/main/kotlin/com/github/psxpaul/task/JavaExecFork.kt
+++ b/src/main/kotlin/com/github/psxpaul/task/JavaExecFork.kt
@@ -1,13 +1,11 @@
 package com.github.psxpaul.task
 
 import org.gradle.api.file.FileCollection
-import org.gradle.api.internal.file.DefaultFileCollectionFactory
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
-import org.gradle.internal.file.PathToFileResolver
 import org.gradle.internal.jvm.Jvm
 import org.gradle.process.JavaForkOptions
-import org.gradle.process.internal.DefaultJavaForkOptions
+import org.gradle.process.internal.JavaForkOptionsFactory
 import javax.inject.Inject
 
 /**
@@ -20,8 +18,8 @@ import javax.inject.Inject
  * @param classpath the classpath to call java with
  * @param main the fully qualified name of the class to execute (e.g. 'com.foo.bar.MainExecutable')
  */
-open class JavaExecFork @Inject constructor(fileResolver: PathToFileResolver) : AbstractExecFork(),
-        JavaForkOptions by DefaultJavaForkOptions(fileResolver, DefaultFileCollectionFactory(fileResolver, null)) {
+open class JavaExecFork @Inject constructor(forkOptionsFactory: JavaForkOptionsFactory) : AbstractExecFork(),
+        JavaForkOptions by forkOptionsFactory.newJavaForkOptions() {
 
     @InputFiles
     var classpath: FileCollection? = null


### PR DESCRIPTION
Hi there,

This PR adds documentation on which Gradle version is compatible with which plugin version (Issue #21), and uses `JavaForkOptionsFactory` to be more robust against internal Gradle API changes in the future.
I also added special handling for #22 as we also run into the issue without an actual crash in the forked process.