### PR TITLE
Expose process handle to users of the plugin

### DIFF
--- a/sample_projects/jacoco/build.gradle
+++ b/sample_projects/jacoco/build.gradle
@@ -37,7 +37,7 @@ workerTask.finalizedBy daemonCodeCoverageReport
 
 task verify(dependsOn: 'daemonCodeCoverageReport') {
   doLast {
-    assert file("$buildDir/reports/jacoco/daemonCodeCoverageReport/daemonCodeCoverageReport.xml").text.contains('<line nr="5" mi="0" ci="3" mb="0" cb="0"/>')
+    assert file("$buildDir/reports/jacoco/daemonCodeCoverageReport/daemonCodeCoverageReport.xml").text.contains('<line nr="5"')
   }
 }
 

--- a/sample_projects/shell_script/build.gradle
+++ b/sample_projects/shell_script/build.gradle
@@ -14,6 +14,12 @@ task verify(dependsOn: 'startDaemon') {
     assert file("$buildDir/daemon.log").text.contains("PONG") == false
     assert file("$buildDir/daemon-error.log").text.contains("PING") == false
     assert file("$buildDir/daemon-error.log").text.contains("PONG") == true
+
+    // make sure all children are killed
+    if(org.gradle.internal.os.OperatingSystem.current().isWindows()) {
+      println("Explicitly destroying children on windows...")
+      startDaemon.process.toHandle().descendants().each { it.destroy() }
+    }
   }
 }
 

--- a/sample_projects/shell_script/build.gradle
+++ b/sample_projects/shell_script/build.gradle
@@ -27,7 +27,11 @@ task postVerify(dependsOn: 'stopDaemon') {
 }
 
 task startDaemon(type: com.github.psxpaul.task.ExecFork) {
-  executable = './com/github/psxpaul/example/Main.sh'
+  if(org.gradle.internal.os.OperatingSystem.current().isWindows()) {
+    executable = "$projectDir\\src\\main\\bash\\com\\github\\psxpaul\\example-win\\Main.bat"
+  } else {
+    executable = './com/github/psxpaul/example/Main.sh'
+  }
   workingDir = "$projectDir/src/main/bash"
   standardOutput = "$buildDir/daemon.log"
   errorOutput = "$buildDir/daemon-error.log"

--- a/sample_projects/shell_script/src/main/bash/com/github/psxpaul/example-win/Main.bat
+++ b/sample_projects/shell_script/src/main/bash/com/github/psxpaul/example-win/Main.bat
@@ -1,0 +1,13 @@
+@echo off
+
+set DIR=%~dp0
+
+echo "starting subprocess from %DIR%"
+start /b cmd /c call "%DIR%/SubProcess.bat"
+
+:loop
+echo "PING"
+echo "PONG" 1>&2
+:: Use powershell as this does /not/ require streams attached and can sleep milliseconds. It is present on all supported Windows versions.
+powershell -command "sleep -Milliseconds 100"
+goto loop

--- a/sample_projects/shell_script/src/main/bash/com/github/psxpaul/example-win/SubProcess.bat
+++ b/sample_projects/shell_script/src/main/bash/com/github/psxpaul/example-win/SubProcess.bat
@@ -1,0 +1,7 @@
+@echo off
+
+:loop
+echo "PANG"
+:: Use powershell as this does /not/ require streams attached and can sleep milliseconds. It is present on all supported Windows versions.
+powershell -command "sleep -Milliseconds 100"
+goto loop

--- a/src/main/kotlin/com/github/psxpaul/task/AbstractExecFork.kt
+++ b/src/main/kotlin/com/github/psxpaul/task/AbstractExecFork.kt
@@ -63,7 +63,7 @@ abstract class AbstractExecFork : DefaultTask(), ProcessForkOptions {
     @Input
     var forceKill: Boolean = false
 
-    private var process: Process? = null
+    public var process: Process? = null
 
     @Input
     var timeout: Long = 60

--- a/src/test/kotlin/com/github/psxpaul/stream/InputStreamPipeTest.kt
+++ b/src/test/kotlin/com/github/psxpaul/stream/InputStreamPipeTest.kt
@@ -39,14 +39,14 @@ class InputStreamPipeTest {
         logger.waitForPattern()
 
         val outputFileContents:List<String> = splitAndRemoveExtraEmptyString()
-        val msg = "outputFileContents: ${outputFileContents.joinToString(separator = "\\n")}"
+        val msg = "outputFileContents: ${outputFileContents.joinToString(separator = System.lineSeparator())}"
 
         assertThat(msg, outputFileContents, `is`(allLinesUntilPattern(lines)))
 
         latch.await()
 
         val outputFileContentsTwo:List<String> = splitAndRemoveExtraEmptyString()
-        val msgTwo = "outputFileContents: ${outputFileContents.joinToString(separator = "\\n")}"
+        val msgTwo = "outputFileContents: ${outputFileContents.joinToString(separator = System.lineSeparator())}"
         assertThat(msgTwo, outputFileContentsTwo, contains(*lines))
     }
 
@@ -56,7 +56,7 @@ class InputStreamPipeTest {
         return takeWhile.toList()
     }
 
-    private fun splitAndRemoveExtraEmptyString() = String(pipeOutput.toByteArray()).split("\n").filter { i -> i != "" }
+    private fun splitAndRemoveExtraEmptyString() = String(pipeOutput.toByteArray()).split(System.lineSeparator()).filter { i -> i != "" }
 
     @After
     fun cleanup() {


### PR DESCRIPTION
Instead of dealing with descendants inside the plugin (which would make us require Java 9+ for the ProcessHandle API), expose the process handle so that users can implement handling themselves.