### PR TITLE
Fix logging behaviour

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,12 +12,12 @@ version = File("VERSION").readText().trim()
 buildDir = File("build/gradle")
 
 dependencies {
-    compile(gradleApi())
-    compile("org.jetbrains.kotlin:kotlin-stdlib:1.3.41")
-    compile("org.jetbrains.kotlin:kotlin-reflect:1.3.41")
+    implementation(gradleApi())
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.3.41")
+    implementation("org.jetbrains.kotlin:kotlin-reflect:1.3.41")
 
-    testCompile("junit:junit:4.12")
-    testCompile("org.hamcrest:hamcrest-all:1.3")
+    testImplementation("junit:junit:4.12")
+    testImplementation("org.hamcrest:hamcrest-all:1.3")
 }
 
 pluginBundle {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
 
     testImplementation("junit:junit:4.12")
     testImplementation("org.hamcrest:hamcrest-all:1.3")
+    testImplementation("io.mockk:mockk:1.10.0")
 }
 
 pluginBundle {

--- a/src/main/kotlin/com/github/psxpaul/stream/OutputStreamLogger.kt
+++ b/src/main/kotlin/com/github/psxpaul/stream/OutputStreamLogger.kt
@@ -9,12 +9,16 @@ import java.io.OutputStream
 class OutputStreamLogger(private val logger: Logger) : OutputStream() {
 
     var sb = StringBuilder()
+    private var wasCR = false
 
     override fun write(b: Int) {
         val character = b.toChar()
-        if (character == '\n') {
+        if (wasCR || character == '\n') {
             logger.lifecycle(sb.toString())
+            wasCR = false
             sb = StringBuilder()
+        } else if (character == '\r') {
+            wasCR = true
         } else
             sb.append(character)
     }

--- a/src/test/kotlin/com/github/psxpaul/stream/OutputStreamLoggerTest.kt
+++ b/src/test/kotlin/com/github/psxpaul/stream/OutputStreamLoggerTest.kt
@@ -1,0 +1,52 @@
+package com.github.psxpaul.stream
+
+import io.mockk.MockKAnnotations
+import org.junit.Test
+import org.gradle.api.logging.Logger
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import org.junit.Before
+
+internal class OutputStreamLoggerTest {
+    @MockK
+    lateinit var logger: Logger
+
+    @Before
+    fun setUp() = MockKAnnotations.init(this, relaxUnitFun = true)
+
+    @Test
+    fun writeWritesLinesWithoutLF() {
+        val sut = OutputStreamLogger(logger)
+        val testString = "test"
+        testString.forEach {
+            sut.write(it.toInt())
+        }
+        sut.write('\n'.toInt())
+        verify { logger.lifecycle(testString) }
+    }
+
+    @Test
+    fun writeWritesLinesWithoutCR() {
+        val sut = OutputStreamLogger(logger)
+        val testString = "test"
+        testString.forEach {
+            sut.write(it.toInt())
+        }
+        sut.write('\r'.toInt())
+        // We need to supply another character to trigger the logging
+        sut.write(' '.toInt())
+        verify { logger.lifecycle(testString) }
+    }
+
+    @Test
+    fun writeWritesLinesWithoutCRLF() {
+        val sut = OutputStreamLogger(logger)
+        val testString = "test"
+        testString.forEach {
+            sut.write(it.toInt())
+        }
+        sut.write('\r'.toInt())
+        sut.write('\n'.toInt())
+        verify { logger.lifecycle(testString) }
+    }
+}


### PR DESCRIPTION
I encountered a bug where the output of the process was not shown on Windows in IntelliJ. The reason for this bug was, that the process is logging lines CRLF line endings. I changed the behaviour of the OutputStreamLogger-Class to handle CRLF, LF and CR line endings.