### PR TITLE
Shorten command line with pathing JAR.

### DIFF
--- a/sample_projects/long_classpath/build.gradle
+++ b/sample_projects/long_classpath/build.gradle
@@ -1,0 +1,32 @@
+apply plugin: 'java'
+apply plugin: 'gradle-execfork-plugin'
+
+buildscript {
+  repositories {
+    mavenLocal()
+    mavenCentral()
+  }
+  dependencies {
+    classpath "com.github.psxpaul:gradle-execfork-plugin:$pluginVersion"
+  }
+}
+
+task integrationTest(dependsOn: 'startDaemon') {
+  doLast {
+    sleep(500)
+    println "I hope the daemon is running"
+  }
+}
+build.dependsOn integrationTest
+
+task startDaemon(type: com.github.psxpaul.task.JavaExecFork, dependsOn: 'classes') {
+  // Add 2048 (non existing) paths to classpath, each more than 128 characters in length.
+  // Passing this classpath as a command-line argument exceeds command line length limits of MS Windows, Linux and macOS.
+  classpath = sourceSets.main.runtimeClasspath.plus(layout.files(
+          (0..2048).stream()
+                  .map { s -> "${'a' * 128}/${s}" }
+                  .toList()
+  ))
+  main = 'com.github.psxpaul.example.Main'
+  args = [ '--someArg', "$buildDir/somePath" ]
+}

--- a/sample_projects/long_classpath/src/main/java/com/github/psxpaul/example/Main.java
+++ b/sample_projects/long_classpath/src/main/java/com/github/psxpaul/example/Main.java
@@ -1,0 +1,12 @@
+package com.github.psxpaul.example;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        System.out.println("Daemon started with args: " + String.join(", ", args));
+        System.out.println("Daemon is now running!");
+        while(true) {
+          System.out.println("PING");
+          Thread.sleep(500);
+        }
+    }
+}

--- a/sample_projects/settings.gradle
+++ b/sample_projects/settings.gradle
@@ -1,6 +1,7 @@
 include 'apply_from'
 include 'env_vars'
 include 'jacoco'
+include 'long_classpath'
 include 'redirect_output'
 include 'redirect_output_and_error'
 include 'shell_script'

--- a/src/main/kotlin/com/github/psxpaul/task/JavaExecFork.kt
+++ b/src/main/kotlin/com/github/psxpaul/task/JavaExecFork.kt
@@ -6,6 +6,14 @@ import org.gradle.api.tasks.InputFiles
 import org.gradle.internal.jvm.Jvm
 import org.gradle.process.JavaForkOptions
 import org.gradle.process.internal.JavaForkOptionsFactory
+import java.io.File
+import java.io.FileOutputStream
+import java.net.URI
+import java.util.jar.Attributes
+import java.util.jar.JarOutputStream
+import java.util.jar.Manifest
+import java.util.stream.Collectors
+import java.util.zip.ZipEntry
 import javax.inject.Inject
 
 /**
@@ -35,6 +43,38 @@ open class JavaExecFork @Inject constructor(forkOptionsFactory: JavaForkOptionsF
         processArgs.addAll(allJvmArgs)
         processArgs.add(main!!)
         processArgs.addAll(args.map(CharSequence::toString))
+
+        if (hasCommandLineExceedMaxLength(processArgs)) {
+            processArgs[processArgs.indexOf("-cp") + 1] =
+                    writePathingJarFile(bootstrapClasspath + classpath).path
+        }
+
         return processArgs
+    }
+
+    private fun writePathingJarFile(classPath: FileCollection): File {
+        val pathingJarFile = File.createTempFile("gradle-javaexec-classpath", ".jar")
+        FileOutputStream(pathingJarFile).use { fileOutputStream ->
+            JarOutputStream(fileOutputStream, toManifest(classPath)).use { jarOutputStream ->
+                jarOutputStream.putNextEntry(ZipEntry("META-INF/"))
+            }
+        }
+        return pathingJarFile
+    }
+
+    private fun toManifest(classPath: FileCollection): Manifest {
+        val manifest = Manifest()
+        val attributes = manifest.mainAttributes
+        attributes[Attributes.Name.MANIFEST_VERSION] = "1.0"
+        attributes.putValue("Class-Path",
+                classPath.files.stream().map(File::toURI).map(URI::toString).collect(Collectors.joining(" ")))
+        return manifest
+    }
+
+    private fun hasCommandLineExceedMaxLength(args: List<String>): Boolean {
+        // See http://msdn.microsoft.com/en-us/library/windows/desktop/ms682425(v=vs.85).aspx
+        // Derived from MAX_ARG_STRLEN as per http://man7.org/linux/man-pages/man2/execve.2.html
+        val maxCommandLineLength = if (System.getProperty("os.name").contains("Windows")) 32767 else 131072
+        return args.joinToString(" ").length > maxCommandLineLength
     }
 }


### PR DESCRIPTION
For long classpaths execution may fail. This is especially prevalent on MS Windows.
See https://github.com/gradle/gradle/issues/10114 for further details of the problem.

This commit copies the fix from Gradle:
https://github.com/gradle/gradle/pull/10544