### PR TITLE
Only instantiate AbstractExecFork tasks eagerly

### DIFF
--- a/src/main/kotlin/com/github/psxpaul/ExecForkPlugin.kt
+++ b/src/main/kotlin/com/github/psxpaul/ExecForkPlugin.kt
@@ -32,15 +32,12 @@ class ExecForkPlugin : Plugin<Project> {
         }
 
         val forkTasks: ArrayList<AbstractExecFork> = ArrayList()
-        project.tasks.whenTaskAdded { task: Task ->
-            if (task is AbstractExecFork) {
-                val forkTask: AbstractExecFork = task
-                val joinTask: ExecJoin = project.tasks.create(createNameFor(forkTask), ExecJoin::class.java)
-                joinTask.forkTask = forkTask
-                forkTask.joinTask = joinTask
+        project.tasks.withType(AbstractExecFork::class.java) { forkTask: AbstractExecFork ->
+            val joinTask: ExecJoin = project.tasks.create(createNameFor(forkTask), ExecJoin::class.java)
+            joinTask.forkTask = forkTask
+            forkTask.joinTask = joinTask
 
-                forkTasks.add(forkTask)
-            }
+            forkTasks.add(forkTask)
         }
 
         project.gradle.addBuildListener(object: BuildAdapter() {


### PR DESCRIPTION
The current plugin calls whenTaskAdded which eagerly initiates all tasks. This breaks [Task Configuration Avoidance](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html) and led to configuration timing issues on our side.

I changed it to withType(java.lang.Class) rather than the recommended withType(java.lang.Class).configureEach(org.gradle.api.Action) because the latter one broke a test. Using withType(java.lang.Class) limits eager instantiation to AbstractExecFork tasks.