### PR TITLE
Fix #39 Can no longer use ExecFork to run an executable from PATH

### DIFF
--- a/src/main/kotlin/com/github/psxpaul/task/AbstractExecFork.kt
+++ b/src/main/kotlin/com/github/psxpaul/task/AbstractExecFork.kt
@@ -44,7 +44,7 @@ abstract class AbstractExecFork : DefaultTask(), ProcessForkOptions {
     @Input
     override abstract fun getEnvironment(): MutableMap<String, Any>
 
-    @InputFile
+    @Input
     override abstract fun getExecutable(): String?
 
     @Input

--- a/src/main/kotlin/com/github/psxpaul/task/ExecFork.kt
+++ b/src/main/kotlin/com/github/psxpaul/task/ExecFork.kt
@@ -1,6 +1,6 @@
 package com.github.psxpaul.task
 
-import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Input
 import org.gradle.process.ProcessForkOptions
 import org.gradle.process.internal.JavaForkOptionsFactory
 import javax.inject.Inject
@@ -20,7 +20,7 @@ open class ExecFork @Inject constructor(forkOptionsFactory: JavaForkOptionsFacto
      * The path to the executable to run
      * @deprecated Use #executable instead
      */
-    @get:InputFile
+    @get:Input
     var commandLine: String?
         get() = executable
         set(value) {


### PR DESCRIPTION
Fix #39 The issue is caused by the `@InputFile` annotation, which will add the working directory path to the `executable`.
