### PR TITLE
[wip] Switch to publishing plugin 1.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ allprojects {
 }
 
 plugins {
-    id("com.gradle.plugin-publish").version("0.14.0")
+    id("com.gradle.plugin-publish").version("1.0.0")
     kotlin("jvm") version "1.5.10"
     id("idea")
     id("maven-publish")
@@ -45,13 +45,16 @@ dependencies {
 pluginBundle {
     website = "http://github.com/psxpaul"
     vcsUrl = "https://github.com/psxpaul/gradle-execfork-plugin"
-    description = "Execute Java or shell processes in the background during a build"
     tags = listOf("java", "exec", "background", "process")
+}
 
-    (plugins) {
+gradlePlugin {
+    plugins {
         create("execForkPlugin") {
             id = "com.github.psxpaul.execfork"
             displayName = "Gradle Exec Fork Plugin"
+            description = "Execute Java or shell processes in the background during a build"
+            implementationClass = "com.github.psxpaul.ExecForkPlugin"
         }
     }
 }

--- a/src/main/resources/META-INF/gradle-plugins/com.github.psxpaul.execfork.properties
+++ b/src/main/resources/META-INF/gradle-plugins/com.github.psxpaul.execfork.properties
@@ -1,1 +1,0 @@
-implementation-class=com.github.psxpaul.ExecForkPlugin


### PR DESCRIPTION
I can't check publishing but here is the instruction https://plugins.gradle.org/docs/publish-plugin and the most probable problem is that plugin group id can't be `com.github` ([1](https://central.sonatype.org/changelog/#2021-04-01-comgithub-is-not-supported-anymore-as-a-valid-coordinate), [2](https://plugins.gradle.org/docs/publish-plugin#troubleshooting))

However sonatype article says that `Current projects already using the com.github groupId in Central are not affected by this change.` so maybe updating an already existing plugin is ok